### PR TITLE
Output ruckusing migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [Wiki](https://github.com/ruckus/ruckusing-migrations/wiki) for the comp
 
 * Portability: the migration files, which describe the tables, columns, indexes, etc to be created are themselves written in pure PHP5 which is then translated to the appropriate SQL at run-time. This allows one to transparently support any RDBMS with a single set of migration files (assuming there is an adapter for it, see below).
 
-* Extensibility: the framework is written with extensibility in mind and it is very modular. Support for new RDMBSs should be as easy as creating the appropriate adapter and implementing a single interface.
+* Extensibility: the framework is written with extensibility in mind, and it is very modular. Support for new RDMBSs should be as easy as creating the appropriate adapter and implementing a single interface.
 
 * "rake" like support for basic tasks. The framework has a concept of "tasks" (in fact the primary focus of the framework, migrations, is just a plain task) which are just basic PHP5 classes which implement an interface. Tasks can be freely written and as long as they adhere to a specific naming convention and implement a specific interface, the framework will automatically register them and allow them to be executed.
 
@@ -25,6 +25,6 @@ See the [Wiki](https://github.com/ruckus/ruckusing-migrations/wiki) for the comp
 
 # Limitations
 
-* PHP5 is a hard requirement. The framework employes extensive use of object-oriented features of PHP5. There are no plans to make the framework backwards compatible.
+* PHP5 is not a hard requirement. Seems to be working in project which uses PHP7. The framework employs extensive use of object-oriented features of PHP5. There are no plans to make the framework backwards compatible.
 
 * As of August 2007, only the MySQL RDBMS is supported.

--- a/lib/tasks/class.Ruckusing_DB_Migrate.php
+++ b/lib/tasks/class.Ruckusing_DB_Migrate.php
@@ -39,8 +39,12 @@ class Ruckusing_DB_Migrate implements Ruckusing_iTask {
 	   die("This database does not support migrations.");
     }
 		$this->task_args = $args;
-		echo "Started: " . date('Y-m-d g:ia T') . "\n\n";		
-		echo "[db:migrate]: \n";
+
+        if (getenv('OUTPUT_RUCKUSING_MIGRATION')) {
+            echo "Started: " . date('Y-m-d g:ia T') . "\n\n";
+            echo "[db:migrate]: \n";
+        }
+
 		try {
   	  // Check that the schema_version table exists, and if not, automatically create it
   	  $this->verify_environment();
@@ -89,8 +93,11 @@ class Ruckusing_DB_Migrate implements Ruckusing_iTask {
 			echo "\tMigration directory does not exist: " . RUCKUSING_MIGRATION_DIR;
 		}catch(Ruckusing_Exception $ex) {
 			die("\n\n" . $ex->getMessage() . "\n\n");
-		}	
-		echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";			
+		}
+
+        if (getenv('OUTPUT_RUCKUSING_MIGRATION')) {
+            echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
+        }
 	}
 	
 	private function migrate_from_offset($offset, $current_version, $direction) {
@@ -156,13 +163,16 @@ class Ruckusing_DB_Migrate implements Ruckusing_iTask {
 
   private function prepare_to_migrate($destination, $direction) {
     try {
-		  echo "\tMigrating " . strtoupper($direction);
-			if(!is_null($destination)) {
-			   echo " to: {$destination}\n";				
-		  } else {
-		    echo ":\n";
-		  }
-			
+        if (getenv('OUTPUT_RUCKUSING_MIGRATION')) {
+            echo "\tMigrating " . strtoupper($direction);
+
+            if (!is_null($destination)) {
+                echo " to: {$destination}\n";
+            } else {
+                echo ":\n";
+            }
+        }
+
 			$templates = $this->adapter->getTemplates($this->task_args);
 			
 			if(array_key_exists('FLAVOUR', $this->task_args))
@@ -213,11 +223,15 @@ class Ruckusing_DB_Migrate implements Ruckusing_iTask {
 						$ex = new Exception(sprintf("%s - %s", $file['class'], $e->getMessage()));
 						throw $ex;
 					}
-					$end = $this->end_timer();
-					$diff = $this->diff_timer($start, $end);
-					printf("========= %s ======== (%.2f)\n", $file['class'], $diff);
+
+                    if (getenv('OUTPUT_RUCKUSING_MIGRATION')) {
+                        $end = $this->end_timer();
+                        $diff = $this->diff_timer($start, $end);
+                        printf("========= %s ======== (%.2f)\n", $file['class'], $diff);
+                        $exec = true;
+                    }
+
 					$last_version = $file['version'];
-					$exec = true;
 				} else {
 					trigger_error("ERROR: {$klass} does not have a '{$target_method}' method defined!");
 				}			


### PR DESCRIPTION
Introducing 'OUTPUT_RUCKUSING_MIGRATION' environment variable.

The 'OUTPUT_RUCKUSING_MIGRATION' environment variable will be used
when no output is wanted on successful migration: 0 - for no output, 1 - for output.
Made some changes to README and removed redundant code. 